### PR TITLE
Update SCC permissions docs for legacy and SA-based onboarding

### DIFF
--- a/Cloud_Providers/GCP/gcp-onboarding-permissions.md
+++ b/Cloud_Providers/GCP/gcp-onboarding-permissions.md
@@ -247,16 +247,40 @@ If `roles/logging.privateLogViewer` cannot be assigned, Tamnoon recommends creat
 
 ## 7. SCC Coverage via Security Reviewer
 
-`roles/iam.securityReviewer` includes 22 SCC permissions — no separate SCC roles needed for standard use:
+`roles/iam.securityReviewer` includes 22 SCC permissions — sufficient for **investigation scripts** that discover and analyze findings:
 
 | SCC Permission | Capability |
 |----------------|------------|
 | `securitycenter.findings.list` | List threat, vulnerability, and misconfiguration findings |
+| `securitycenter.issues.list` | List SCC issues (grouped findings) |
 | `securitycenter.assets.list` | List SCC asset inventory |
 | `securitycenter.attackpaths.list` | List attack path simulations |
 | `securitycenter.sources.list` | List SCC finding sources |
 
-**When separate SCC roles ARE still needed**: If Tamnoon is onboarded at **project level** (no `roles/iam.securityReviewer`), or if SCC is activated at folder level and the customer needs granular SCC role control. See [SCC Integration](gcp-scc-integration.md) for folder-level role details.
+### What `iam.securityReviewer` does NOT include
+
+The following SCC permissions require `roles/securitycenter.findingsViewer` (which is a superset of `roles/securitycenter.issuesViewer` — never grant both):
+
+| Permission | Capability | When needed |
+|------------|-----------|-------------|
+| `securitycenter.issues.get` | Fetch a specific Issue by ID | Programmatic SCC alert ingestion |
+| `securitycenter.findings.group` | Aggregate findings by category/severity | Dashboard / reporting |
+| `securitycenter.findingexplanations.get` | SCC AI-generated finding explanations | Enriched alert context |
+| `securitycenter.graphs.get` / `.query` | Attack graph traversal | Finding correlation |
+| `securitycenter.issues.group` / `.listFilterValues` | Issue aggregation and filter discovery | Issue-level analytics |
+
+### When to use which role
+
+| Use Case | Role | Scope |
+|----------|------|-------|
+| **Investigation scripts** (`--csv-input` driven) | `roles/iam.securityReviewer` (already in onboarding) | Org / Folder / Project |
+| **SCC alert ingestion** (Tamnoon Alerts page) | `roles/securitycenter.findingsViewer` (add to the same SA) | Org or Project (SCC doesn't support folder-level activation) |
+
+**Legacy onboarding** (current): `tamnoonpoc@tamnoon.io` user account — add `findingsViewer` to the same user for SCC ingestion.
+
+**SA-based onboarding** (May 2026+): A single SA handles both investigation and SCC ingestion. Grant both the onboarding roles and `findingsViewer` — they are additive with minimal overlap.
+
+See [SCC Integration](gcp-scc-integration.md) for setup details.
 
 ---
 
@@ -265,5 +289,6 @@ If `roles/logging.privateLogViewer` cannot be assigned, Tamnoon recommends creat
 | Integration | Purpose | Configuration | Doc |
 |-------------|---------|---------------|-----|
 | **Google Workspace** | Enrich user/group investigations with identity context (name, OU, status, group membership) | Domain-wide delegation with Admin SDK read-only scopes | [Workspace Integration](gcp-workspace-integration.md) |
+| **SCC Alert Ingestion** | Programmatic ingestion of SCC findings into Tamnoon Alerts page | Dedicated SA with `findingsViewer` at org or project scope | [SCC Integration](gcp-scc-integration.md) |
 
-**Note**: Workspace is the only integration that requires configuration beyond the standard onboarding roles. SCC access is already covered by `roles/iam.securityReviewer` at org/folder scope.
+**Note**: Workspace and SCC Alert Ingestion are the only integrations that require configuration beyond the standard onboarding roles. For investigation scripts, SCC access is already covered by `roles/iam.securityReviewer` at org/folder scope.

--- a/Cloud_Providers/GCP/gcp-scc-integration.md
+++ b/Cloud_Providers/GCP/gcp-scc-integration.md
@@ -2,58 +2,231 @@
 
 # GCP Security Command Center Integration
 
-## Standard Path — No Separate SCC Roles Needed
-
-`roles/iam.securityReviewer` (assigned during [standard onboarding](gcp-onboarding-permissions.md)) includes 22 SCC permissions:
-
-| Permission | Capability |
-|------------|------------|
-| `securitycenter.findings.list` | List threat, vulnerability, and misconfiguration findings |
-| `securitycenter.assets.list` | List SCC asset inventory |
-| `securitycenter.attackpaths.list` | List attack path simulations |
-| `securitycenter.sources.list` | List SCC finding sources |
-| `securitycenter.muteconfigs.list` | List mute configurations |
-| `securitycenter.notificationconfig.list` | List notification configs |
-| + 16 additional list/read permissions | Compliance snapshots, risk reports, custom modules, valued resources |
-
-**No additional configuration is required** when Tamnoon is onboarded at organization or folder level with `roles/iam.securityReviewer`.
+This document defines the permissions needed for Tamnoon to ingest SCC findings into the Tamnoon Alerts page. This is separate from the standard onboarding ([gcp-onboarding-permissions.md](gcp-onboarding-permissions.md)) which covers investigation scripts.
 
 ---
 
-## Fallback — Dedicated SCC Roles
+## 1. Prerequisites
 
-Dedicated SCC roles are only needed when:
-- The customer wants **granular SCC role control** separate from the security reviewer role
-- SCC is activated at folder level and the customer prefers dedicated SCC roles per folder
-- `roles/iam.securityReviewer` cannot be assigned for policy reasons
+### SCC Activation
 
-### Organization-Level SCC
+SCC must be activated before the integration has anything to ingest. SCC supports activation at **Organization** or **Project** scope only — folder-level SCC activation is not supported ([reference](https://cloud.google.com/security-command-center/docs/activate-scc-overview)).
 
-| Role | Permissions | Scope |
-|------|-------------|-------|
-| `roles/securitycenter.adminViewer` | Read-only access to ALL assets, findings, attack paths, and security sources | Organization-wide |
+| SCC Tier | Where SCC can be activated |
+|---|---|
+| Standard | Organization OR Project |
+| Premium | Organization OR Project |
+| Enterprise | Organization only |
 
-### Folder-Level SCC
+Verify activation:
+```bash
+# Org-level
+gcloud scc settings services list --organization=ORG_ID
+
+# Project-level
+gcloud scc settings services list --project=PROJECT_ID
+```
+
+### Operator Permissions
+
+The person performing the setup needs:
+
+**To create the service account** (on the tenant project where the SA lives):
+
+| Task | Role |
+|---|---|
+| Create the SA | `roles/iam.serviceAccountAdmin` |
+| Set IAM policy on the SA (required for WIF / impersonation) | `roles/iam.serviceAccountAdmin` |
+| Create WIF pool & provider (recommended over keys) | `roles/iam.workloadIdentityPoolAdmin` |
+
+**To grant the SA `findingsViewer`** at the SCC activation scope:
+
+| Integration Scope | Operator Requirement |
+|---|---|
+| **Organization** | `roles/resourcemanager.organizationAdmin` OR `roles/iam.securityAdmin` at org |
+| **Project(s)** | `roles/resourcemanager.projectIamAdmin` OR `roles/owner` on each project |
+
+---
+
+## 2. Tamnoon Principal
+
+### Legacy onboarding (current)
+
+Customers onboarded before May 2026 use the **Tamnoon user account** (`tamnoonpoc@tamnoon.io`). For SCC integration on legacy onboarding, grant `findingsViewer` to the existing user:
+
+```bash
+gcloud organizations add-iam-policy-binding ORG_ID \
+  --member="user:tamnoonpoc@tamnoon.io" \
+  --role="roles/securitycenter.findingsViewer" \
+  --condition=None
+```
+
+### Service Account onboarding (May 2026+)
+
+Starting May 2026, Tamnoon uses a **single service account** for both investigation and SCC alert ingestion. If the onboarding SA already exists, add `findingsViewer` to it — do not create a separate SA.
+
+**Existing SA** (onboarding already done):
+```bash
+SA="serviceAccount:tamnoon-sa@TENANT_PROJECT.iam.gserviceaccount.com"
+
+gcloud organizations add-iam-policy-binding ORG_ID \
+  --member="$SA" \
+  --role="roles/securitycenter.findingsViewer" \
+  --condition=None
+```
+
+**New customer** (onboarding + SCC integration from day one):
+```bash
+gcloud iam service-accounts create tamnoon-sa \
+  --display-name="Tamnoon Security Engineering" \
+  --project=TENANT_PROJECT
+```
+Then grant both the [onboarding roles](gcp-onboarding-permissions.md#2-roles-assigned-to-tamnoon) AND `findingsViewer` (Section 4 below).
+
+**Authentication**: Workload Identity Federation (recommended) or Service Account Key (legacy).
+
+---
+
+## 3. Role Assigned to the SA
 
 | Role | Purpose |
-|------|---------|
-| `roles/securitycenter.assetsViewer` | Read access to SCC assets |
-| `roles/securitycenter.findingsViewer` | Read access to SCC findings |
-| `roles/securitycenter.attackPathsViewer` | Read access to SCC attack path simulations |
+|---|---|
+| `roles/securitycenter.findingsViewer` | List and retrieve SCC findings and issues |
 
-All three roles must be granted on **each folder** where SCC is active.
+**Why this role**: `findingsViewer` is a superset of `issuesViewer` — do not grant both. It provides:
 
-**Note**: `roles/securitycenter.attackPathsViewer` cannot be granted at project level.
+- `securitycenter.findings.list`, `findings.group`, `findings.listFindingPropertyNames`
+- `securitycenter.issues.list`, `issues.get`, `issues.group`, `issues.listFilterValues`
+- `securitycenter.findingexplanations.get`
+- `securitycenter.graphs.get`, `graphs.query`
+- `securitycenter.sources.list`, `sources.get`
+- `securitycenter.compliancesnapshots.list`, `vulnerabilitysnapshots.list`
+- `resourcemanager.folders.get`, `organizations.get`, `projects.get`
 
 ---
 
-## What Tamnoon Ingests
+## 4. Integration Scope — Grant Commands
+
+Grant `findingsViewer` at a scope that covers all projects where SCC is activated.
+
+### 4.1 Organization-Level (Recommended)
+
+```bash
+SA="serviceAccount:tamnoon-scc-integration@TENANT_PROJECT.iam.gserviceaccount.com"
+
+gcloud organizations add-iam-policy-binding ORG_ID \
+  --member="$SA" \
+  --role="roles/securitycenter.findingsViewer" \
+  --condition=None
+```
+
+Coverage: All current and future projects in the organization.
+
+### 4.2 Project-Level (Multiple Projects)
+
+Use when SCC is activated per-project (Standard/Premium without org-level activation).
+
+```bash
+SA="serviceAccount:tamnoon-scc-integration@TENANT_PROJECT.iam.gserviceaccount.com"
+
+for PROJECT in project-a project-b project-c; do
+  gcloud projects add-iam-policy-binding "$PROJECT" \
+    --member="$SA" \
+    --role="roles/securitycenter.findingsViewer" \
+    --condition=None
+done
+```
+
+Or from a file (one project ID per line):
+
+```bash
+while IFS= read -r PROJECT; do
+  [[ -z "$PROJECT" || "$PROJECT" =~ ^# ]] && continue
+  gcloud projects add-iam-policy-binding "$PROJECT" \
+    --member="$SA" \
+    --role="roles/securitycenter.findingsViewer" \
+    --condition=None
+done < projects.txt
+```
+
+**Limitations of project-level**:
+- No cross-project attack paths
+- No org-wide asset inventory correlation
+- Must re-run when new projects activate SCC
+
+---
+
+## 5. Quota Project
+
+The SCC API requires a quota project with `securitycenter.googleapis.com` enabled:
+
+```bash
+gcloud projects add-iam-policy-binding TENANT_PROJECT \
+  --member="$SA" \
+  --role="roles/serviceusage.serviceUsageConsumer" \
+  --condition=None
+```
+
+Use `--billing-project=TENANT_PROJECT` in gcloud commands or `x-goog-user-project` header for REST calls.
+
+---
+
+## 6. Verification
+
+```bash
+# Check role binding
+gcloud organizations get-iam-policy ORG_ID \
+  --flatten="bindings[].members" \
+  --filter="bindings.members:tamnoon-scc-integration" \
+  --format="table(bindings.role)"
+
+# Test finding access
+gcloud scc findings list organizations/ORG_ID \
+  --location=global \
+  --impersonate-service-account=tamnoon-scc-integration@TENANT_PROJECT.iam.gserviceaccount.com \
+  --filter='state="ACTIVE"' \
+  --limit=5
+```
+
+---
+
+## 7. Relationship to Standard Onboarding
+
+### Legacy onboarding (user-based)
+
+| Principal | Onboarding roles | SCC integration | Status |
+|-----------|-----------------|-----------------|--------|
+| `tamnoonpoc@tamnoon.io` | 6 predefined + `TamnoonSecurityAssessment` | Add `findingsViewer` to same user | Current |
+
+### SA-based onboarding (May 2026+)
+
+A **single SA** handles both investigation and SCC ingestion. The roles are additive with minimal overlap (`findings.list` and `issues.list` are duplicated, which is harmless).
+
+| Source | Roles |
+|--------|-------|
+| [Standard onboarding](gcp-onboarding-permissions.md) | `roles/viewer`, `roles/browser`, `roles/iam.securityReviewer`, `roles/cloudasset.viewer`, `roles/logging.privateLogViewer`, `roles/serviceusage.serviceUsageConsumer`, `TamnoonSecurityAssessment` (custom) |
+| SCC integration (**this doc**) | `roles/securitycenter.findingsViewer` |
+
+### What each part provides
+
+| Capability | Provided by |
+|-----------|------------|
+| List findings for investigation scripts | `iam.securityReviewer` (onboarding) |
+| Fetch individual Issues by ID | `findingsViewer` (this doc) |
+| Finding aggregation, explanations, graph queries | `findingsViewer` (this doc) |
+| Read resources, IAM policies, audit logs | Onboarding roles |
+| GKE secrets, container image scanning | `TamnoonSecurityAssessment` (onboarding) |
+
+---
+
+## 8. What Tamnoon Ingests
 
 | SCC Data Type | Usage |
 |---------------|-------|
 | **Threat findings** (active) | Correlate with IAM bindings — which identities have access to affected resources |
 | **Vulnerability findings** | Prioritize remediation based on exposure (network access + IAM scope) |
-| **Asset inventory** | Cross-reference with IAM analysis for comprehensive resource coverage |
+| **Misconfiguration findings** | Surface compliance gaps (open ports, public access, key rotation) |
+| **Issues** (grouped findings) | Aggregate related findings for investigation prioritization |
 | **Attack paths** | Understand lateral movement risk through IAM role chains |
 
 See also:


### PR DESCRIPTION
## Summary
- Update `gcp-onboarding-permissions.md` Section 7 (SCC Coverage) with findingsViewer gap analysis and role guidance for both legacy user and SA-based onboarding
- Rewrite `gcp-scc-integration.md` for the single-SA model (May 2026+) while maintaining legacy user path

## Key changes
- Document what `iam.securityReviewer` does NOT include for SCC (issues.get, findings.group, explanations, graphs)
- `findingsViewer` is superset of `issuesViewer` — never grant both
- SCC activation: org or project only (removed incorrect folder-level reference)
- Legacy path: add `findingsViewer` to existing `tamnoonpoc@tamnoon.io` user
- SA path (May 2026+): single SA gets onboarding roles + `findingsViewer`
- Operator permissions, multi-project grant commands, quota project requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)