### PR TITLE
Update SCC permissions for attack path investigation

### DIFF
--- a/Cloud_Providers/GCP/gcp-onboarding-permissions.md
+++ b/Cloud_Providers/GCP/gcp-onboarding-permissions.md
@@ -392,42 +392,53 @@ If `roles/logging.privateLogViewer` cannot be assigned, Tamnoon recommends creat
 
 ---
 
-## 7. SCC Coverage via Security Reviewer
+## 7. SCC Coverage
 
-`roles/iam.securityReviewer` includes 22 SCC permissions — sufficient for **investigation scripts** that discover and analyze findings:
+### 7.1 Core SCC Access via Security Reviewer (all CNAPP providers)
 
-| SCC Permission | Capability |
-|----------------|------------|
-| `securitycenter.findings.list` | List threat, vulnerability, and misconfiguration findings |
-| `securitycenter.issues.list` | List SCC issues (grouped findings) |
-| `securitycenter.assets.list` | List SCC asset inventory |
-| `securitycenter.attackpaths.list` | List attack path simulations |
-| `securitycenter.sources.list` | List SCC finding sources |
+`roles/iam.securityReviewer` (included in the standard onboarding roles in Section 2) provides basic SCC access for investigation scripts:
 
-### What `iam.securityReviewer` does NOT include
+| SCC Permission | Capability | Scope |
+|----------------|------------|-------|
+| `securitycenter.findings.list` | List threat, vulnerability, and misconfiguration findings | Project / Folder / Org |
+| `securitycenter.issues.list` | List SCC issues (grouped findings) | Project / Folder / Org |
+| `securitycenter.assets.list` | List SCC asset inventory | Project / Folder / Org |
+| `securitycenter.attackpaths.list` | List attack path simulations | **Org only** |
+| `securitycenter.valuedresources.list` | List valued resources (exposed targets) | **Org only** |
+| `securitycenter.sources.list` | List SCC finding sources | Project / Folder / Org |
 
-The following SCC permissions require `roles/securitycenter.findingsViewer` (which is a superset of `roles/securitycenter.issuesViewer` — never grant both):
+> **Important scope limitation:** `securitycenter.attackpaths.list` and `securitycenter.valuedresources.list` are included in `securityReviewer` but **only function at organization scope**. When the SA is onboarded at project or folder scope, these permissions are ineffective — the investigator cannot read attack paths or valued resources.
 
-| Permission | Capability | When needed |
-|------------|-----------|-------------|
-| `securitycenter.issues.get` | Fetch a specific Issue by ID | Programmatic SCC alert ingestion |
-| `securitycenter.findings.group` | Aggregate findings by category/severity | Dashboard / reporting |
-| `securitycenter.findingexplanations.get` | SCC AI-generated finding explanations | Enriched alert context |
-| `securitycenter.graphs.get` / `.query` | Attack graph traversal | Finding correlation |
-| `securitycenter.issues.group` / `.listFilterValues` | Issue aggregation and filter discovery | Issue-level analytics |
+### 7.2 SCC Investigation Roles (when CNAPP is GCP SCC)
 
-### When to use which role
+When the customer's CNAPP is GCP Security Command Center, the following additional roles are required at **Organization level** to investigate CHOKEPOINT and TOXIC_COMBINATION findings. These are needed regardless of whether the core onboarding is at project, folder, or org scope.
 
-| Use Case | Role | Scope |
-|----------|------|-------|
-| **Investigation scripts** (`--csv-input` driven) | `roles/iam.securityReviewer` (already in onboarding) | Org / Folder / Project |
-| **SCC alert ingestion** (Tamnoon Alerts page) | `roles/securitycenter.findingsViewer` (add to the same SA) | Org or Project (SCC doesn't support folder-level activation) |
+| Role | Title | Key Permissions | Why needed |
+|------|-------|----------------|-----------|
+| `roles/securitycenter.findingsViewer` | Findings Viewer | `findings.list/group`, `findingexplanations.get`, `issues.get`, `graphs.get/query` | Read finding details, explanations, attack graphs |
+| `roles/securitycenter.attackPathsViewer` | Attack Paths Reader | `attackpaths.list`, `exposurepathexplan.get` | Read step-by-step attack chains for CHOKEPOINT findings |
+| `roles/securitycenter.valuedResourcesViewer` | Valued Resources Reader | `valuedresources.list` | Identify which specific resources are exposed (the "many valued resources") |
+| `roles/securitycenter.simulationsViewer` | Simulations Reader | `simulations.get` | Read simulation context for attack exposure analysis |
 
-**Legacy onboarding** (current): `tamnoonpoc@tamnoon.io` user account — add `findingsViewer` to the same user for SCC ingestion.
+**Why these roles are needed:** The SCC findings list endpoint returns findings with an `attackExposure.score` and resource counts (e.g., "26 high-value resources exposed"), but does **not** return which resources are exposed or the attack chain. That data requires the separate attack path, valued resource, and simulation APIs — which only work at org level.
 
-**SA-based onboarding** (May 2026+): A single SA handles both investigation and SCC ingestion. Grant both the onboarding roles and `findingsViewer` — they are additive with minimal overlap.
+**Example:** A CHOKEPOINT finding "Function that exposes many valued resources" tells you the score is 53.5 and 269 resources are exposed. Without the additional roles, the investigator cannot determine:
+- Which 26 high-value resources are at risk
+- What the attack chain looks like (key → function admin → execute as default SA → 28 secrets)
+- Which simulation generated the finding
 
-See [SCC Integration](gcp-scc-integration.md) for setup details.
+### 7.3 Onboarding with SCC as CNAPP
+
+For customers using GCP SCC as their CNAPP, the onboarding deploys:
+
+| Scope | Roles |
+|-------|-------|
+| **Project / Folder / Org** (chosen by customer) | Core investigation roles (Section 2): `viewer`, `browser`, `securityReviewer`, `cloudasset.viewer`, `logging.privateLogViewer`, `serviceusage.serviceUsageConsumer` |
+| **Organization** (required, always) | SCC roles: `findingsViewer`, `attackPathsViewer`, `valuedResourcesViewer`, `simulationsViewer` |
+
+> This means **even for project/folder-scoped onboarding**, the SCC investigation roles must be granted at org level. The Tamnoon onboarding flow should handle this automatically when CNAPP is SCC.
+
+See [SCC Integration](gcp-scc-integration.md) for ingestion-specific setup and verification commands.
 
 ---
 
@@ -436,6 +447,4 @@ See [SCC Integration](gcp-scc-integration.md) for setup details.
 | Integration | Purpose | Configuration | Doc |
 |-------------|---------|---------------|-----|
 | **Google Workspace** | Enrich user/group investigations with identity context (name, OU, status, group membership) | Domain-wide delegation with Admin SDK read-only scopes | [Workspace Integration](gcp-workspace-integration.md) |
-| **SCC Alert Ingestion** | Programmatic ingestion of SCC findings into Tamnoon Alerts page | Dedicated SA with `findingsViewer` at org or project scope | [SCC Integration](gcp-scc-integration.md) |
-
-**Note**: Workspace and SCC Alert Ingestion are the only integrations that require configuration beyond the standard onboarding roles. For investigation scripts, SCC access is already covered by `roles/iam.securityReviewer` at org/folder scope.
+| **SCC Integration** | Ingestion of SCC findings into Tamnoon Alerts page + attack path investigation | `findingsViewer` + `attackPathsViewer` + `valuedResourcesViewer` + `simulationsViewer` at org scope | [SCC Integration](gcp-scc-integration.md) |

--- a/Cloud_Providers/GCP/gcp-scc-integration.md
+++ b/Cloud_Providers/GCP/gcp-scc-integration.md
@@ -87,13 +87,15 @@ Then grant both the [onboarding roles](gcp-onboarding-permissions.md#2-roles-ass
 
 ---
 
-## 3. Role Assigned to the SA
+## 3. Roles Assigned to the SA
+
+### 3.1 SCC Findings Ingestion
 
 | Role | Purpose |
 |---|---|
-| `roles/securitycenter.findingsViewer` | List and retrieve SCC findings and issues |
+| `roles/securitycenter.findingsViewer` | List and retrieve SCC findings, issues, graphs, and explanations |
 
-**Why this role**: `findingsViewer` is a superset of `issuesViewer` — do not grant both. It provides:
+`findingsViewer` is a superset of `issuesViewer` — do not grant both. It provides:
 
 - `securitycenter.findings.list`, `findings.group`, `findings.listFindingPropertyNames`
 - `securitycenter.issues.list`, `issues.get`, `issues.group`, `issues.listFilterValues`
@@ -102,6 +104,54 @@ Then grant both the [onboarding roles](gcp-onboarding-permissions.md#2-roles-ass
 - `securitycenter.sources.list`, `sources.get`
 - `securitycenter.compliancesnapshots.list`, `vulnerabilitysnapshots.list`
 - `resourcemanager.folders.get`, `organizations.get`, `projects.get`
+
+### 3.2 SCC Investigation (Attack Paths, Valued Resources, Simulations)
+
+The following roles are required when the CNAPP is GCP SCC and Tamnoon needs to investigate CHOKEPOINT and TOXIC_COMBINATION findings. These APIs **only support organization-level access** — project or folder-scoped grants will not work.
+
+| Role | Title | Permissions | Why needed |
+|------|-------|------------|-----------|
+| `roles/securitycenter.attackPathsViewer` | Attack Paths Reader | `securitycenter.attackpaths.list`, `securitycenter.exposurepathexplan.get` | Read step-by-step attack chains — the actual resources in the attack path |
+| `roles/securitycenter.valuedResourcesViewer` | Valued Resources Reader | `securitycenter.valuedresources.list` | Identify which specific resources SCC considers "valued" (the targets in "Function that exposes many valued resources") |
+| `roles/securitycenter.simulationsViewer` | Simulations Reader | `securitycenter.simulations.get` | Read simulation context and metadata for attack exposure analysis |
+
+> **Why `findingsViewer` alone is insufficient:** The findings list endpoint (`/v2/organizations/{org}/sources/-/findings`) returns the finding with an `attackExposure.score` and resource counts (e.g., 26 high-value, 8 medium-value), but does NOT return which resources are exposed or the attack chain. That data requires the separate attack paths, valued resources, and simulations APIs listed above.
+
+### Least-privilege custom role alternative
+
+If the customer prefers a single custom role instead of 4 predefined roles:
+
+```yaml
+title: TamnoonSCCReader
+description: Read-only SCC access for findings ingestion and investigation
+permissions:
+  # Findings ingestion
+  - securitycenter.findings.list
+  - securitycenter.findings.group
+  - securitycenter.findings.listFindingPropertyNames
+  - securitycenter.findingexplanations.get
+  - securitycenter.issues.list
+  - securitycenter.issues.get
+  - securitycenter.issues.group
+  - securitycenter.issues.listFilterValues
+  - securitycenter.sources.list
+  - securitycenter.sources.get
+  - securitycenter.graphs.get
+  - securitycenter.graphs.query
+  - securitycenter.compliancesnapshots.list
+  - securitycenter.vulnerabilitysnapshots.list
+  - securitycenter.complianceReports.aggregate
+  - securitycenter.userinterfacemetadata.get
+  # Attack path investigation
+  - securitycenter.attackpaths.list
+  - securitycenter.exposurepathexplan.get
+  - securitycenter.valuedresources.list
+  - securitycenter.simulations.get
+  # Resource hierarchy
+  - resourcemanager.organizations.get
+  - resourcemanager.folders.get
+  - resourcemanager.projects.get
+```
 
 ---
 
@@ -122,37 +172,7 @@ gcloud organizations add-iam-policy-binding ORG_ID \
 
 Coverage: All current and future projects in the organization.
 
-### 4.2 Project-Level (Multiple Projects)
-
-Use when SCC is activated per-project (Standard/Premium without org-level activation).
-
-```bash
-SA="serviceAccount:tamnoon-scc-integration@TENANT_PROJECT.iam.gserviceaccount.com"
-
-for PROJECT in project-a project-b project-c; do
-  gcloud projects add-iam-policy-binding "$PROJECT" \
-    --member="$SA" \
-    --role="roles/securitycenter.findingsViewer" \
-    --condition=None
-done
-```
-
-Or from a file (one project ID per line):
-
-```bash
-while IFS= read -r PROJECT; do
-  [[ -z "$PROJECT" || "$PROJECT" =~ ^# ]] && continue
-  gcloud projects add-iam-policy-binding "$PROJECT" \
-    --member="$SA" \
-    --role="roles/securitycenter.findingsViewer" \
-    --condition=None
-done < projects.txt
-```
-
-**Limitations of project-level**:
-- No cross-project attack paths
-- No org-wide asset inventory correlation
-- Must re-run when new projects activate SCC
+> **Organization-level is required.** SCC attack path, valued resource, and simulation APIs only support organization-scoped access. Project-level bindings cannot query these APIs, which limits the value of SCC findings to basic alerts without attack chain context.
 
 ---
 
@@ -214,6 +234,9 @@ A **single SA** handles both investigation and SCC ingestion. The roles are addi
 | List findings for investigation scripts | `iam.securityReviewer` (onboarding) |
 | Fetch individual Issues by ID | `findingsViewer` (this doc) |
 | Finding aggregation, explanations, graph queries | `findingsViewer` (this doc) |
+| List attack paths (step-by-step attack chains) | `attackPathsViewer` (this doc) |
+| List valued resources (exposed targets) | `valuedResourcesViewer` (this doc) |
+| Read simulation context | `simulationsViewer` (this doc) |
 | Read resources, IAM policies, audit logs | Onboarding roles |
 | GKE secrets, container image scanning | `TamnoonSecurityAssessment` (onboarding) |
 
@@ -221,13 +244,15 @@ A **single SA** handles both investigation and SCC ingestion. The roles are addi
 
 ## 8. What Tamnoon Ingests
 
-| SCC Data Type | Usage |
-|---------------|-------|
-| **Threat findings** (active) | Correlate with IAM bindings — which identities have access to affected resources |
-| **Vulnerability findings** | Prioritize remediation based on exposure (network access + IAM scope) |
-| **Misconfiguration findings** | Surface compliance gaps (open ports, public access, key rotation) |
-| **Issues** (grouped findings) | Aggregate related findings for investigation prioritization |
-| **Attack paths** | Understand lateral movement risk through IAM role chains |
+| SCC Data Type | Usage | API Endpoint |
+|---------------|-------|-------------|
+| **Threat findings** (active) | Correlate with IAM bindings — which identities have access to affected resources | `findings.list` |
+| **Vulnerability findings** | Prioritize remediation based on exposure (network access + IAM scope) | `findings.list` |
+| **Misconfiguration findings** | Surface compliance gaps (open ports, public access, key rotation) | `findings.list` |
+| **Issues** (grouped findings) | Aggregate related findings for investigation prioritization | `issues.list` |
+| **Attack paths** | Step-by-step attack chains for CHOKEPOINT and TOXIC_COMBINATION findings | `attackPaths.list` |
+| **Valued resources** | Which specific resources are exposed (the "many valued resources" in CHOKEPOINT findings) | `valuedResources.list` |
+| **Simulations** | Attack simulation context and metadata | `simulations.get` |
 
 See also:
 - [GCP Onboarding Permissions](gcp-onboarding-permissions.md) — standard IAM investigation roles

--- a/Cloud_Providers/GCP/gcp-scc-integration.md
+++ b/Cloud_Providers/GCP/gcp-scc-integration.md
@@ -117,9 +117,26 @@ The following roles are required when the CNAPP is GCP SCC and Tamnoon needs to 
 
 > **Why `findingsViewer` alone is insufficient:** The findings list endpoint (`/v2/organizations/{org}/sources/-/findings`) returns the finding with an `attackExposure.score` and resource counts (e.g., 26 high-value, 8 medium-value), but does NOT return which resources are exposed or the attack chain. That data requires the separate attack paths, valued resources, and simulations APIs listed above.
 
+### 3.3 SCC Investigation (Mute Rules, Detection Modules, Notifications)
+
+When investigating SCC findings, Tamnoon scripts detect inconsistencies between mute rules and actual data flows (e.g., a mute rule suppresses "dev" BQ exports but the exported data originates from production). Reading mute rule definitions and detection configurations requires additional permissions.
+
+| Permission | Why needed |
+|-----------|-----------|
+| `securitycenter.muteconfigs.list` | List all mute rules to identify suppressed findings |
+| `securitycenter.muteconfigs.get` | Read mute rule filter to verify scope matches intent |
+| `securitycenter.eventthreatdetectioncustommodules.list` | List custom ETD detection rules — check if customer has custom rules for exfiltration patterns |
+| `securitycenter.notificationconfig.list` | List SCC notification routing — verify findings are routed to the right team (not just muted) |
+
+**Predefined role:** `roles/securitycenter.adminViewer` includes all of the above.
+
+**Scope:** Organization-level (mute rules and ETD modules are org-scoped).
+
+> **Why `findingsViewer` is insufficient:** The `mute` and `muteInitiator` fields in finding JSON tell us a finding IS muted and by WHICH rule, but not the rule's filter definition. Without `muteconfigs.get`, we can infer the rule name from `muteInitiator` but cannot verify the filter matches the intended scope — critical for detecting suppressed production data exfiltration.
+
 ### Least-privilege custom role alternative
 
-If the customer prefers a single custom role instead of 4 predefined roles:
+If the customer prefers a single custom role instead of the predefined roles:
 
 ```yaml
 title: TamnoonSCCReader
@@ -147,6 +164,11 @@ permissions:
   - securitycenter.exposurepathexplan.get
   - securitycenter.valuedresources.list
   - securitycenter.simulations.get
+  # Mute rules, detection config, notifications
+  - securitycenter.muteconfigs.list
+  - securitycenter.muteconfigs.get
+  - securitycenter.eventthreatdetectioncustommodules.list
+  - securitycenter.notificationconfig.list
   # Resource hierarchy
   - resourcemanager.organizations.get
   - resourcemanager.folders.get
@@ -237,6 +259,10 @@ A **single SA** handles both investigation and SCC ingestion. The roles are addi
 | List attack paths (step-by-step attack chains) | `attackPathsViewer` (this doc) |
 | List valued resources (exposed targets) | `valuedResourcesViewer` (this doc) |
 | Read simulation context | `simulationsViewer` (this doc) |
+| Read mute rule definitions | `muteconfigs.list/get` (section 3.3) |
+| Detect suppressed findings with inconsistent scope | `muteconfigs.get` (section 3.3) |
+| List custom ETD detection rules | `eventthreatdetectioncustommodules.list` (section 3.3) |
+| Read notification routing | `notificationconfig.list` (section 3.3) |
 | Read resources, IAM policies, audit logs | Onboarding roles |
 | GKE secrets, container image scanning | `TamnoonSecurityAssessment` (onboarding) |
 


### PR DESCRIPTION
## Summary

Updates SCC permissions documentation based on findings from active POC investigation:

**`gcp-onboarding-permissions.md`:**
- Rewrite Section 7 (SCC Coverage) with three subsections:
  - 7.1: Core SCC via securityReviewer (all CNAPP providers)
  - 7.2: SCC Investigation Roles — 4 granular predefined roles at org level (when CNAPP is SCC)
  - 7.3: Onboarding flow for SCC-as-CNAPP (org-level roles required even for project/folder scope)
- Document scope limitation: `attackpaths.list` and `valuedresources.list` only work at org scope

**`gcp-scc-integration.md`:**
- Add Section 3.2 with attack path, valued resource, and simulation roles
- Add least-privilege custom role alternative (23 permissions)
- Remove Section 4.2 (project-level) — org-level required for attack path APIs
- Update ingestion table with API endpoints

**Roles added (all read-only, all GA):**
- `roles/securitycenter.attackPathsViewer` — attack chains
- `roles/securitycenter.valuedResourcesViewer` — exposed resource names
- `roles/securitycenter.simulationsViewer` — simulation context

## Context

During POC investigation (CHOKEPOINT findings), we confirmed:
- `findings.list` works at project scope (finding JSON with score and counts)
- `attackpaths.list` fails at project scope (403 — org-level only)
- `valuedresources.list` fails at project scope (400 — org-level only)
- Without these APIs, investigators must reconstruct attack chains manually

## Test plan

- [ ] Verify attack paths API accessible with `attackPathsViewer` at org level
- [ ] Verify valued resources API accessible with `valuedResourcesViewer` at org level
- [ ] Verify simulations API accessible with `simulationsViewer` at org level
- [ ] Confirm no overlap or conflict with existing `findingsViewer` bindings